### PR TITLE
Correctly parse suggestions containing multiple words

### DIFF
--- a/aspell.js
+++ b/aspell.js
@@ -21,7 +21,7 @@ function parseLine(line) {
 		type: "misspelling",
 		word: parts[1],
 		position: (ctrl == "#" ? parts[2] : parts[3]) | 0,
-		alternatives: line.substring(line.indexOf(':')).split(/,\s/g)
+		alternatives: ctrl == "#" ? [] : line.substring(line.indexOf(':') + 2).split(/,\s/g)
 	};
 }
 

--- a/aspell.js
+++ b/aspell.js
@@ -21,7 +21,7 @@ function parseLine(line) {
 		type: "misspelling",
 		word: parts[1],
 		position: (ctrl == "#" ? parts[2] : parts[3]) | 0,
-		alternatives: parts.slice(4)
+		alternatives: line.substring(line.indexOf(':')).split(/,\s/g)
 	};
 }
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -16,11 +16,11 @@ const tests = [
 				position: 0,
 				alternatives: [
 					"mistake",   "misstate",
-					"miss",      "take",
-					"miss-take", "mistaken",
-					"mistakes",  "misspoke",
-					"misstep",   "mistake's",
-					"mistook",   "stake"
+					"miss take", "miss-take",
+					"mistaken",  "mistakes",
+					"misspoke",  "misstep",
+					"mistake's", "mistook",
+					"stake"
 				]
 			}
 		],


### PR DESCRIPTION
When not using the "--run-together" argument, aspell will treat compound words like "webdesign" as a misspelling, and provide "web design" as the first suggestion. This is not parsed correctly by the current code, and the suggestions list starts with "web" and "design" as two separate items. This PR re-parses the suggestions part of the line, splitting only on commas and not simply whitespace, to deliver multiple-word suggestions as a single item as intended.

Thanks for this module, btw -- still works great under Node 16!




